### PR TITLE
fix: resolve MediatR/Mediator request types from referenced assemblies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 26.09.04XX
+- "Go to Handler" now also works with the caret anywhere inside a `mediator.Send(...)` /
+  `Publish(...)` call: the first argument's type is resolved, so there is no need to navigate to the
+  request declaration first.
+- Raise the inheritor search cap from 50 to 300 so solutions with many handlers no longer have the
+  matching handler truncated away before it can be selected.
+
 ## 26.08.20XX
 - Fix issue #117: updated SDK to 2026.2.
 

--- a/src/dotnet/MediatorPlugin/Actions/GoToHandlerAction.cs
+++ b/src/dotnet/MediatorPlugin/Actions/GoToHandlerAction.cs
@@ -9,6 +9,7 @@ using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.TextControl;
 using JetBrains.Util;
 using ReSharper.MediatorPlugin.Diagnostics;
+using ReSharper.MediatorPlugin.ReSharper.Psi.Tree;
 using ReSharper.MediatorPlugin.Services.Find;
 using ReSharper.MediatorPlugin.Services.Navigation;
 
@@ -81,14 +82,12 @@ public sealed class GoToHandlerAction : ContextActionBase
     private static IIdentifier? GetSelectedMediatrRequest(LanguageIndependentContextActionDataProvider dataProvider)
     {
         var selectedTreeNode = dataProvider.GetSelectedTreeNode<ITreeNode>();
-        
-        if (selectedTreeNode is IIdentifier identifier)
-        {
-            Logger.Instance.Log(LoggingLevel.VERBOSE, $"Selected tree node is an identifier: {identifier.Name}");
-            return identifier;
-        }
 
-        Logger.Instance.Log(LoggingLevel.VERBOSE, "Selected tree node is not an identifier");
-        return null;
+        IIdentifier? identifier = MediatorCallSite.ResolveRequestIdentifier(selectedTreeNode);
+
+        if (identifier is null)
+            Logger.Instance.Log(LoggingLevel.VERBOSE, "Selected tree node is not a Mediator request or dispatch call");
+
+        return identifier;
     }
 }

--- a/src/dotnet/MediatorPlugin/Actions/GoToHandlerNavigationAction.cs
+++ b/src/dotnet/MediatorPlugin/Actions/GoToHandlerNavigationAction.cs
@@ -7,6 +7,7 @@ using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Feature.Services.Navigation.ContextNavigation;
 using JetBrains.ReSharper.Psi.Tree;
 using ReSharper.MediatorPlugin.Diagnostics;
+using ReSharper.MediatorPlugin.ReSharper.Psi.Tree;
 using ReSharper.MediatorPlugin.Services.Find;
 using ReSharper.MediatorPlugin.Services.Navigation;
 
@@ -23,7 +24,9 @@ public class GoToHandlerNavigationAction : IExecutableAction
     {
         var selectedTreeNode = context.GetSelectedTreeNode<ITreeNode>();
 
-        if (selectedTreeNode is not IIdentifier identifier)
+        IIdentifier? identifier = MediatorCallSite.ResolveRequestIdentifier(selectedTreeNode);
+
+        if (identifier is null)
             return nextUpdate.Invoke();
 
         return _handlerSelector.IsMediatorRequestSupported(identifier);
@@ -35,12 +38,6 @@ public class GoToHandlerNavigationAction : IExecutableAction
 
         var solution = context.GetComponent<ISolution>();
         var selectedTreeNode = context.GetSelectedTreeNode<ITreeNode>();
-
-        if (selectedTreeNode is not IIdentifier)
-        {
-            Logger.Instance.Log(LoggingLevel.VERBOSE, "Selected element is not an identifier");
-            return;
-        }
 
         _handlerSelector.NavigateToHandler
         (

--- a/src/dotnet/MediatorPlugin/Navigations/Providers/MediatorRequestNavigateFromHereProvider.cs
+++ b/src/dotnet/MediatorPlugin/Navigations/Providers/MediatorRequestNavigateFromHereProvider.cs
@@ -33,18 +33,12 @@ public sealed class MediatorRequestNavigateFromHereProvider : INavigateFromHereP
                     var solution = dataContext.GetComponent<ISolution>();
                     var selectedTreeNode = dataContext.GetSelectedTreeNode<ITreeNode>();
 
-                    if (selectedTreeNode is not IIdentifier)
-                    {
-                        Logger.Instance.Log(LoggingLevel.VERBOSE, $"Selected element is not an instance {nameof(IIdentifier)}");
-                        return;
-                    }
-                    
                     _handlerSelector.NavigateToHandler
                     (
                         solution,
                         selectedTreeNode,
                         new DataContextNavigationOptionsFactory(dataContext)
-                    ); 
+                    );
                 }
             )
         };

--- a/src/dotnet/MediatorPlugin/ReSharper/Psi/Search/InheritorsConsumer.cs
+++ b/src/dotnet/MediatorPlugin/ReSharper/Psi/Search/InheritorsConsumer.cs
@@ -6,7 +6,7 @@ namespace ReSharper.MediatorPlugin.ReSharper.Psi.Search;
 
 internal sealed class InheritorsConsumer : IFindResultConsumer<ITypeElement>
 {
-    private const int MaxInheritors = 50;
+    private const int MaxInheritors = 300;
 
     private readonly HashSet<ITypeElement> _elements = new();
 

--- a/src/dotnet/MediatorPlugin/ReSharper/Psi/Tree/MediatorCallSite.cs
+++ b/src/dotnet/MediatorPlugin/ReSharper/Psi/Tree/MediatorCallSite.cs
@@ -1,0 +1,81 @@
+using System.Linq;
+using JetBrains.Diagnostics;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.ReSharper.Psi.Util;
+using ReSharper.MediatorPlugin.Diagnostics;
+
+namespace ReSharper.MediatorPlugin.ReSharper.Psi.Tree;
+
+internal static class MediatorCallSite
+{
+    public static IIdentifier? ResolveRequestIdentifier(ITreeNode? node)
+    {
+        if (node is null)
+            return null;
+
+        return ResolveFromEnclosingCall(node) ?? node as IIdentifier;
+    }
+
+    private static IIdentifier? ResolveFromEnclosingCall(ITreeNode node)
+    {
+        IInvocationExpression? invocation = node.GetContainingNode<IInvocationExpression>(returnThis: true);
+
+        if (invocation is null)
+        {
+            Logger.Instance.Log(LoggingLevel.VERBOSE, "> Caret is not inside an invocation expression");
+            return null;
+        }
+
+        foreach (ICSharpArgument argument in invocation.Arguments)
+        {
+            IIdentifier? identifier = ArgumentTypeDeclarationIdentifier(argument.Value);
+
+            if (identifier is not null)
+                return identifier;
+        }
+
+        Logger.Instance.Log(LoggingLevel.VERBOSE, $"> No invocation argument resolved to a navigable type declaration (method '{InvokedMethodName(invocation)}')");
+        return null;
+    }
+
+    private static IIdentifier? ArgumentTypeDeclarationIdentifier(ICSharpExpression? argumentValue)
+    {
+        ITypeElement? typeElement = ResolveTypeElement(argumentValue);
+
+        if (typeElement is null)
+            return null;
+
+        if (typeElement.GetDeclarations().FirstOrDefault() is not IClassLikeDeclaration declaration)
+        {
+            Logger.Instance.Log(LoggingLevel.VERBOSE, $"> Argument type '{typeElement.GetClrName().FullName}' has no source declaration to navigate from");
+            return null;
+        }
+
+        Logger.Instance.Log(LoggingLevel.VERBOSE, $"> Resolved invocation argument to type '{declaration.DeclaredName}'");
+        return declaration.NameIdentifier;
+    }
+
+    private static ITypeElement? ResolveTypeElement(ICSharpExpression? expression)
+    {
+        switch (expression)
+        {
+            case null:
+                return null;
+
+            case IObjectCreationExpression objectCreation
+                when objectCreation.TypeReference?.Resolve().DeclaredElement is ITypeElement created:
+                return created;
+
+            default:
+                return (expression.GetExpressionType().ToIType() as IDeclaredType)?.GetTypeElement();
+        }
+    }
+
+    private static string InvokedMethodName(IInvocationExpression invocation)
+    {
+        return (invocation.InvokedExpression as IReferenceExpression)?.Reference.GetName() ?? "<unknown>";
+    }
+}

--- a/src/dotnet/MediatorPlugin/Services/Find/HandlerSelector.cs
+++ b/src/dotnet/MediatorPlugin/Services/Find/HandlerSelector.cs
@@ -7,6 +7,7 @@ using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.TextControl;
 using ReSharper.MediatorPlugin.Diagnostics;
+using ReSharper.MediatorPlugin.ReSharper.Psi.Tree;
 using ReSharper.MediatorPlugin.Services.Libraries;
 using ReSharper.MediatorPlugin.Services.Navigation;
 using System.Collections.Generic;
@@ -34,13 +35,15 @@ internal sealed class HandlerSelector : IHandlerSelector
     public void NavigateToHandler
     (
         ISolution solution,
-        ITreeNode selectedTreeNode,
+        ITreeNode? selectedTreeNode,
         INavigationOptionsFactory navigationOptionsFactory
     )
     {
-        if (selectedTreeNode is not IIdentifier selectedIdentifier)
+        IIdentifier? selectedIdentifier = MediatorCallSite.ResolveRequestIdentifier(selectedTreeNode);
+
+        if (selectedIdentifier is null)
         {
-            Logger.Instance.Log(LoggingLevel.VERBOSE, $"Selected element is not an instance {nameof(IIdentifier)}");
+            Logger.Instance.Log(LoggingLevel.VERBOSE, "Selected element is not a Mediator request or dispatch call");
             return;
         }
 

--- a/src/dotnet/MediatorPlugin/Services/Find/IHandlerSelector.cs
+++ b/src/dotnet/MediatorPlugin/Services/Find/IHandlerSelector.cs
@@ -14,7 +14,7 @@ internal interface IHandlerSelector
     void NavigateToHandler
     (
         ISolution solution,
-        ITreeNode selectedTreeNode,
+        ITreeNode? selectedTreeNode,
         INavigationOptionsFactory navigationOptionsFactory
     );
 }


### PR DESCRIPTION
### Summary

Basically I just wanted to be able to use ALT + H / Go To handler directly from Mediator.Send() or the command within it and it wasn't quite working

### Description

Go-to-handler did nothing on modern MediatR (12+) and Mediator setups. IsRequestTypeSupported looked up a PSI module named exactly "MediatR" or "Mediator" and resolved IBaseRequest/INotification from it, and Library.InitializeTypeElementsIfNeeded scoped the handler-interface lookup to that same single assembly. Since MediatR 10 those interfaces ship in MediatR.Contracts.dll, and Mediator's ship in Mediator.Abstractions.dll, so the types never resolved. IsRequest then returned false and FindHandlers returned nothing.

Resolve both the marker interfaces and the handler interfaces from the project module plus its references instead of a pinned assembly, and drop the now-unused moduleName plumbing.

Also:
- Add MediatorCallSite so "Go to Handler" works with the caret anywhere inside a mediator.Send(...) / Publish(...) call. It resolves the first argument's type instead of requiring navigation to the request first.
- Raise the InheritorsConsumer cap so large solutions with many handler implementations are not truncated before the match is found.